### PR TITLE
Include phone in customer search

### DIFF
--- a/src/app/clientes/components/client-list.tsx
+++ b/src/app/clientes/components/client-list.tsx
@@ -150,7 +150,8 @@ export function ClientList({ customerToOpen }: ClientListProps) {
         const searchLower = searchTerm.toLowerCase();
         return customer.name.toLowerCase().includes(searchLower) ||
                (customer.doc && customer.doc.toLowerCase().includes(searchLower)) ||
-               (customer.email && customer.email.toLowerCase().includes(searchLower));
+               (customer.email && customer.email.toLowerCase().includes(searchLower)) ||
+               (customer.phone && customer.phone.toLowerCase().includes(searchLower));
       })
       .filter((customer) => statusFilter === 'all' ? true : customer.status === statusFilter)
       .filter((customer) => {
@@ -273,7 +274,7 @@ export function ClientList({ customerToOpen }: ClientListProps) {
             <div className="relative w-full max-w-sm">
                 <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" />
                 <Input 
-                    placeholder="Buscar por nome, documento ou email..."
+                    placeholder="Buscar por nome, documento, email ou telefone..."
                     className="pl-10"
                     value={searchTerm}
                     onChange={(e) => setSearchTerm(e.target.value)}


### PR DESCRIPTION
## Summary
- expand client search filter to check phone numbers
- mention phone in the search input placeholder

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*
- `npm run typecheck` *(fails: src/app/pdv/page.tsx(257,1): error TS1005: '}' expected.)*

------
https://chatgpt.com/codex/tasks/task_e_68a87f36e90c8329831aff9ba1ab39b5