### PR TITLE
feat: open client details on card click

### DIFF
--- a/src/app/clientes/components/client-list.tsx
+++ b/src/app/clientes/components/client-list.tsx
@@ -291,7 +291,11 @@ export function ClientList({ customerToOpen }: ClientListProps) {
         
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
             {filteredCustomers.map((customer) => (
-                <Card key={customer.id} className="shadow-sm hover:shadow-lg transition-shadow">
+                <Card
+                    key={customer.id}
+                    className="shadow-sm hover:shadow-lg transition-shadow cursor-pointer"
+                    onClick={() => handleViewDetails(customer)}
+                >
                     <CardHeader className="flex flex-row items-start justify-between">
                         <div className="flex items-center gap-4">
                             <div className="bg-primary/10 text-primary p-3 rounded-full">


### PR DESCRIPTION
## Summary
- make client cards clickable to show details

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint setup)*
- `npm run typecheck` *(fails: src/app/pdv/page.tsx(257,1): error TS1005: '}' expected)*

------
https://chatgpt.com/codex/tasks/task_e_68a87f4ef3508329aec5aae00c804994