### PR TITLE
Add customer linkage to financial movements

### DIFF
--- a/src/ai/flows/register-sale.ts
+++ b/src/ai/flows/register-sale.ts
@@ -110,6 +110,7 @@ const registerSaleFlow = ai.defineFlow(
         const financialMovement: Omit<FinancialMovement, 'id'> = {
           description: movementDescription,
           referenceId: saleRef.id,
+          customerId,
           dueDate: isSaleOnCredit ? dueDate : format(today, 'yyyy-MM-dd'),
           paymentDate: movementStatus === 'paid' ? format(today, 'yyyy-MM-dd') : undefined,
           amount: totalAmount,
@@ -118,11 +119,6 @@ const registerSaleFlow = ai.defineFlow(
           category: 'vendas',
           sourceAccount,
         };
-        
-        // If sale is on credit, link financial movement to customer for receivable tracking
-        if (isSaleOnCredit && customerId) {
-          financialMovement.referenceId = customerId; 
-        }
         
         const movementRef = doc(collection(db, 'financialMovements'));
         transaction.set(movementRef, financialMovement);

--- a/src/app/clientes/components/client-list.tsx
+++ b/src/app/clientes/components/client-list.tsx
@@ -109,7 +109,7 @@ export function ClientList({ customerToOpen }: ClientListProps) {
     try {
         const salesQuery = query(collection(db, 'sales'), where('customerId', '==', customer.id), orderBy('date', 'desc'));
         const exchangesQuery = query(collection(db, 'exchanges'), where('customerId', '==', customer.id), orderBy('date', 'desc'));
-        const financialsQuery = query(collection(db, 'financialMovements'), where('referenceId', '==', customer.id));
+        const financialsQuery = query(collection(db, 'financialMovements'), where('customerId', '==', customer.id));
 
         const [salesSnapshot, exchangesSnapshot, financialsSnapshot] = await Promise.all([
             getDocs(salesQuery),

--- a/src/app/pdv/page.tsx
+++ b/src/app/pdv/page.tsx
@@ -254,3 +254,4 @@ export default function PdvPage() {
       </Dialog>
     </>
   );
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -74,6 +74,7 @@ export interface FinancialMovement {
     paymentDate?: string;
     category: ExpenseCategory;
     referenceId?: string; // e.g., purchaseId or saleId
+    customerId?: string;
     employeeId?: string;
     sourceAccount: SourceAccount;
 }


### PR DESCRIPTION
## Summary
- keep financial movement `referenceId` as sale ID and store optional `customerId`
- query customer financial history by `customerId` instead of `referenceId`
- fix missing closing brace in PDV page

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run typecheck` *(fails: multiple TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a883d058a883299ef29cd9ef623086