### PR TITLE
Import doc for transfer funds flow

### DIFF
--- a/src/ai/flows/transfer-funds.ts
+++ b/src/ai/flows/transfer-funds.ts
@@ -8,7 +8,7 @@
 import { ai } from '@/ai/genkit';
 import { z } from 'zod';
 import { db } from '@/lib/firebase';
-import { collection, writeBatch } from 'firebase/firestore';
+import { collection, doc, writeBatch } from 'firebase/firestore';
 import type { FinancialMovement, SourceAccount } from '@/lib/types';
 import { format } from 'date-fns';
 


### PR DESCRIPTION
## Summary
- import `doc` from `firebase/firestore` in transfer funds flow

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: interactive ESLint configuration prompt)*
- `npm run typecheck` *(fails: src/app/pdv/page.tsx(257,1): error TS1005: '}' expected)*

------
https://chatgpt.com/codex/tasks/task_e_68a883d0d0548329aba845846bf928f2