### PR TITLE
feat: capture payment details when settling customer

### DIFF
--- a/src/ai/flows/settle-customer-payment.ts
+++ b/src/ai/flows/settle-customer-payment.ts
@@ -9,13 +9,17 @@
 import { ai } from '@/ai/genkit';
 import { z } from 'zod';
 import { db } from '@/lib/firebase';
-import { doc, runTransaction, increment, getDoc } from 'firebase/firestore';
+import { doc, runTransaction, increment } from 'firebase/firestore';
 import { format } from 'date-fns';
 
 const SettleCustomerPaymentInputSchema = z.object({
   movementId: z.string().describe('The ID of the financial movement to be settled.'),
   customerId: z.string().describe('The ID of the customer.'),
   amount: z.number().describe('The amount being paid.'),
+  sourceAccount: z.enum(['cash', 'bank']).describe('Account where the payment was deposited.'),
+  paymentMethod: z
+    .enum(['pix', 'boleto', 'dinheiro', 'cartao_credito', 'cartao_debito'])
+    .describe('The payment method used.'),
 });
 
 const SettleCustomerPaymentOutputSchema = z.object({
@@ -34,7 +38,7 @@ const settleCustomerPaymentFlow = ai.defineFlow(
     inputSchema: SettleCustomerPaymentInputSchema,
     outputSchema: SettleCustomerPaymentOutputSchema,
   },
-  async ({ movementId, customerId, amount }) => {
+  async ({ movementId, customerId, amount, sourceAccount, paymentMethod }) => {
     
     await runTransaction(db, async (transaction) => {
       const movementRef = doc(db, 'financialMovements', movementId);
@@ -52,6 +56,8 @@ const settleCustomerPaymentFlow = ai.defineFlow(
       transaction.update(movementRef, {
         status: 'paid',
         paymentDate: format(new Date(), 'yyyy-MM-dd'),
+        sourceAccount,
+        paymentMethod,
       });
 
       // 2. Decrement customer's pending amount

--- a/src/app/clientes/components/client-list.tsx
+++ b/src/app/clientes/components/client-list.tsx
@@ -33,7 +33,7 @@ import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardHeader, CardTitle, CardContent, CardFooter, CardDescription } from '@/components/ui/card';
 import { MoreHorizontal, PlusCircle, Search, Trash2, Edit, XCircle, FileText, ShoppingBag, Repeat, DollarSign, User, Building, Mail, Phone, MapPin, CreditCard, Package, RefreshCw, Calendar, Eye, Loader2, ArrowRight } from 'lucide-react';
-import type { Customer, FinancialMovement, Sale, Exchange, Product } from '@/lib/types';
+import type { Customer, FinancialMovement, Sale, Exchange, Product, PaymentMethod, SourceAccount } from '@/lib/types';
 import PageHeader from '@/components/page-header';
 import { useToast } from '@/hooks/use-toast';
 import { Label } from '@/components/ui/label';
@@ -69,6 +69,10 @@ export function ClientList({ customerToOpen }: ClientListProps) {
   const [customerExchanges, setCustomerExchanges] = useState<Exchange[]>([]);
   const [isHistoryLoading, setIsHistoryLoading] = useState(false);
   const [isSettlingPayment, setIsSettlingPayment] = useState<string | null>(null);
+  const [isSettleDialogOpen, setIsSettleDialogOpen] = useState(false);
+  const [movementToSettle, setMovementToSettle] = useState<FinancialMovement | null>(null);
+  const [settlePaymentMethod, setSettlePaymentMethod] = useState<PaymentMethod>('pix');
+  const [settleSourceAccount, setSettleSourceAccount] = useState<SourceAccount>('bank');
   
   const { toast } = useToast();
   
@@ -214,19 +218,23 @@ export function ClientList({ customerToOpen }: ClientListProps) {
     }
   }
 
-  const handleSettlePayment = async (movement: FinancialMovement) => {
-    if (!selectedCustomer) return;
-    setIsSettlingPayment(movement.id);
+  const handleSettlePayment = async () => {
+    if (!selectedCustomer || !movementToSettle) return;
+    setIsSettlingPayment(movementToSettle.id);
     try {
         const result = await settleCustomerPayment({
-            movementId: movement.id,
+            movementId: movementToSettle.id,
             customerId: selectedCustomer.id,
-            amount: movement.amount,
+            amount: movementToSettle.amount,
+            sourceAccount: settleSourceAccount,
+            paymentMethod: settlePaymentMethod,
         });
         toast({ title: "Sucesso!", description: result.message });
-        
+
         await handleViewDetails(selectedCustomer);
         await fetchData();
+        setIsSettleDialogOpen(false);
+        setMovementToSettle(null);
     } catch (err) {
         const error = err as Error;
         toast({ title: "Erro ao dar baixa", description: error.message, variant: 'destructive' });
@@ -249,6 +257,50 @@ export function ClientList({ customerToOpen }: ClientListProps) {
 
   return (
     <>
+      <Dialog open={isSettleDialogOpen} onOpenChange={setIsSettleDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Registrar Pagamento</DialogTitle>
+            <DialogDescription>Informe os dados do pagamento.</DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label>Método de Pagamento</Label>
+              <Select value={settlePaymentMethod} onValueChange={setSettlePaymentMethod}>
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="Selecione o método" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="pix">PIX</SelectItem>
+                  <SelectItem value="boleto">Boleto</SelectItem>
+                  <SelectItem value="dinheiro">Dinheiro</SelectItem>
+                  <SelectItem value="cartao_credito">Cartão de Crédito</SelectItem>
+                  <SelectItem value="cartao_debito">Cartão de Débito</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label>Conta de Origem</Label>
+              <Select value={settleSourceAccount} onValueChange={setSettleSourceAccount}>
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="Selecione a conta" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="cash">Caixa Físico</SelectItem>
+                  <SelectItem value="bank">Conta Corrente</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setIsSettleDialogOpen(false)}>Cancelar</Button>
+            <Button onClick={handleSettlePayment} disabled={isSettlingPayment === movementToSettle?.id}>
+              {isSettlingPayment === movementToSettle?.id ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : 'Confirmar'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
       <PageHeader title="Gestão de Clientes">
          <div className='flex items-center gap-2'>
             <Select value={statusFilter} onValueChange={setStatusFilter}>
@@ -475,9 +527,14 @@ export function ClientList({ customerToOpen }: ClientListProps) {
                                                         </TableCell>
                                                         <TableCell className='text-right'>
                                                             {m.status === 'pending' && (
-                                                                <Button 
-                                                                    size="sm" 
-                                                                    onClick={() => handleSettlePayment(m)} 
+                                                                <Button
+                                                                    size="sm"
+                                                                    onClick={() => {
+                                                                        setMovementToSettle(m);
+                                                                        setSettlePaymentMethod('pix');
+                                                                        setSettleSourceAccount('bank');
+                                                                        setIsSettleDialogOpen(true);
+                                                                    }}
                                                                     disabled={isSettlingPayment === m.id}
                                                                 >
                                                                     {isSettlingPayment === m.id ? <Loader2 className="h-4 w-4 animate-spin"/> : 'Dar Baixa'}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -76,6 +76,7 @@ export interface FinancialMovement {
     referenceId?: string; // e.g., purchaseId or saleId
     employeeId?: string;
     sourceAccount: SourceAccount;
+    paymentMethod?: PaymentMethod;
 }
 
 export interface PurchaseItem {


### PR DESCRIPTION
## Summary
- include payment method and source account in settle customer payment flow
- persist payment details on financial movement
- prompt users for payment info before settling in client list UI

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run typecheck` *(fails: src/app/pdv/page.tsx(257,1): error TS1005: '}' expected.)*


------
https://chatgpt.com/codex/tasks/task_e_68a88c38c72c83298821690db67bbe55