### PR TITLE
link financial movements to customers

### DIFF
--- a/src/ai/flows/register-sale.ts
+++ b/src/ai/flows/register-sale.ts
@@ -110,6 +110,7 @@ const registerSaleFlow = ai.defineFlow(
         const financialMovement: Omit<FinancialMovement, 'id'> = {
           description: movementDescription,
           referenceId: saleRef.id,
+          customerId,
           dueDate: isSaleOnCredit ? dueDate : format(today, 'yyyy-MM-dd'),
           paymentDate: movementStatus === 'paid' ? format(today, 'yyyy-MM-dd') : undefined,
           amount: totalAmount,
@@ -118,11 +119,8 @@ const registerSaleFlow = ai.defineFlow(
           category: 'vendas',
           sourceAccount,
         };
-        
-        // If sale is on credit, link financial movement to customer for receivable tracking
-        if (isSaleOnCredit && customerId) {
-          financialMovement.referenceId = customerId; 
-        }
+
+        // referenceId always points to the sale document; customerId links to the client when applicable
         
         const movementRef = doc(collection(db, 'financialMovements'));
         transaction.set(movementRef, financialMovement);

--- a/src/app/clientes/components/client-list.tsx
+++ b/src/app/clientes/components/client-list.tsx
@@ -109,7 +109,7 @@ export function ClientList({ customerToOpen }: ClientListProps) {
     try {
         const salesQuery = query(collection(db, 'sales'), where('customerId', '==', customer.id), orderBy('date', 'desc'));
         const exchangesQuery = query(collection(db, 'exchanges'), where('customerId', '==', customer.id), orderBy('date', 'desc'));
-        const financialsQuery = query(collection(db, 'financialMovements'), where('referenceId', '==', customer.id));
+        const financialsQuery = query(collection(db, 'financialMovements'), where('customerId', '==', customer.id));
 
         const [salesSnapshot, exchangesSnapshot, financialsSnapshot] = await Promise.all([
             getDocs(salesQuery),

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -74,6 +74,7 @@ export interface FinancialMovement {
     paymentDate?: string;
     category: ExpenseCategory;
     referenceId?: string; // e.g., purchaseId or saleId
+    customerId?: string;
     employeeId?: string;
     sourceAccount: SourceAccount;
 }


### PR DESCRIPTION
## Summary
- keep sale referenceId while linking financial movements to customer ids
- add optional `customerId` field to `FinancialMovement` type
- filter client financial movements by `customerId`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck` *(fails: src/app/pdv/page.tsx(257,1): error TS1005: '}' expected.)*


------
https://chatgpt.com/codex/tasks/task_e_68a88c37cf188329ba3e97282b912526