### PR TITLE
Add missing doc import in transfer funds flow

### DIFF
--- a/src/ai/flows/transfer-funds.ts
+++ b/src/ai/flows/transfer-funds.ts
@@ -8,7 +8,7 @@
 import { ai } from '@/ai/genkit';
 import { z } from 'zod';
 import { db } from '@/lib/firebase';
-import { collection, writeBatch } from 'firebase/firestore';
+import { collection, doc, writeBatch } from 'firebase/firestore';
 import type { FinancialMovement, SourceAccount } from '@/lib/types';
 import { format } from 'date-fns';
 


### PR DESCRIPTION
## Summary
- include `doc` in Firestore imports for transfer funds flow

## Testing
- `npm run typecheck` *(fails: src/app/pdv/page.tsx(257,1): error TS1005: '}' expected.)*


------
https://chatgpt.com/codex/tasks/task_e_68a88c369d208329920779b06c45c124