### PR TITLE
docs: use Netly for deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,19 @@
-# Firebase Studio
+# Netly Starter
 
-This is a NextJS starter in Firebase Studio.
+This is a Next.js starter configured for deployment on Netly.
 
-To get started, take a look at src/app/page.tsx.
+To get started, take a look at `src/app/page.tsx`.
+
+## Desenvolvimento Local
+
+1. Instale as dependências: `npm install`
+2. Inicie o servidor de desenvolvimento: `npm run dev` e acesse `http://localhost:9002`.
+
+## Implantação na Netly
+
+1. Crie um novo site no painel da Netly e conecte este repositório.
+2. Defina o comando de build como `npm run build` e o diretório de publicação como `.next`.
+3. Configure as variáveis de ambiente necessárias no painel da Netly.
+4. Faça commit e push para a branch principal para disparar o deploy.
+5. Utilize o painel da Netly para acompanhar logs e reimplantações.
+

--- a/docs/blueprint.md
+++ b/docs/blueprint.md
@@ -31,3 +31,10 @@
 - Fonte do corpo e do título: 'PT Sans', uma fonte humanista sans-serif para legibilidade.
 - Uso de ícones simples e modernos para representar diferentes funções e pontos de dados.
 - Manutenção de um layout limpo e baseado em grade com espaçamento consistente para facilitar a digestão das informações.
+
+## Implantação e Configuração na Netly
+
+1. Crie um novo site na Netly e conecte este repositório Git.
+2. Configure o comando de build como `npm run build` e o diretório de publicação como `.next`.
+3. Defina as variáveis de ambiente necessárias no painel da Netly.
+4. Salve e acompanhe o processo de implantação pelo painel.


### PR DESCRIPTION
## Summary
- replace Firebase references with Netly in README
- document Netly deployment steps

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive setup)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a9389bc42883298309a100d460b16d