### PR TITLE
chore: specify Node 18 runtime

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,9 @@
   command = "npm run build"
   publish = ".next"
 
+[build.environment]
+  NODE_VERSION = "18"
+
 [[plugins]]
   package = "@netlify/plugin-nextjs"
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "nextn",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": ">=18"
+  },
   "scripts": {
     "dev": "next dev --turbopack -p 9002",
     "genkit:dev": "genkit start -- tsx src/ai/dev.ts",


### PR DESCRIPTION
## Summary
- declare Node.js 18 support in package.json
- set Netlify build environment to Node 18

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: interactive ESLint configuration prompt)

------
https://chatgpt.com/codex/tasks/task_e_68a93adcb6b08329afff2bf50553863c