### PR TITLE
refactor: wrap financeiro page in suspense

### DIFF
--- a/src/app/financeiro/page.tsx
+++ b/src/app/financeiro/page.tsx
@@ -15,12 +15,12 @@ import { LatestTransactions } from './components/latest-transactions';
 import { EmployeeFinancialReport } from './components/employee-financial-report';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { useState } from 'react';
+import { Suspense, useState } from 'react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
 import { TransferFundsForm } from './components/transfer-funds-form';
 
 
-export default function FinanceiroPage() {
+function FinanceiroPageContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const defaultTab = searchParams.get('tab') || 'overview';
@@ -163,5 +163,13 @@ export default function FinanceiroPage() {
           </DialogContent>
       </Dialog>
     </>
+  );
+}
+
+export default function FinanceiroPage() {
+  return (
+    <Suspense fallback={<div>Carregando...</div>}>
+      <FinanceiroPageContent />
+    </Suspense>
   );
 }


### PR DESCRIPTION
## Summary
- add Suspense wrapper around Financeiro page content
- move Financeiro page logic into a child component

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*
- `npm run typecheck`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a93d89b3308329858db44b4d6b2bf2