### PR TITLE
refactor: import initial products for sales report

### DIFF
--- a/src/app/relatorios/vendas/page.tsx
+++ b/src/app/relatorios/vendas/page.tsx
@@ -19,7 +19,7 @@ import { CalendarIcon, Sparkles, Loader2, TrendingUp, TrendingDown, Package, Use
 import PageHeader from '@/components/page-header';
 import { Separator } from '@/components/ui/separator';
 import { analyzeSales, type SalesAnalysisInput, type SalesAnalysisOutput } from '@/ai/flows/analyze-sales';
-import { products } from '@/lib/data';
+import { initialProducts as products } from '@/lib/data';
 
 
 const formSchema = z.object({


### PR DESCRIPTION
## Summary
- use `initialProducts` alias in sales report

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint src/app/relatorios/vendas/page.tsx` *(fails: ESLint couldn't find an eslint.config file)*
- `npm run typecheck` *(fails: multiple TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a93d7c28048329abf4ae37857943c3