### PR TITLE
Disable TypeScript and ESLint build ignores

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,10 +3,10 @@ import type {NextConfig} from 'next';
 const nextConfig: NextConfig = {
   /* config options here */
   typescript: {
-    ignoreBuildErrors: true,
+    ignoreBuildErrors: false,
   },
   eslint: {
-    ignoreDuringBuilds: true,
+    ignoreDuringBuilds: false,
   },
   images: {
     // Allow data URIs


### PR DESCRIPTION
## Summary
- ensure Next.js build fails on TypeScript or ESLint issues

## Testing
- `npm run lint` *(fails: requires interactive configuration)*
- `npm run typecheck` *(fails: TS2345 etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a93af4838883299547fca7be7f0175