### PR TITLE
chore: remove Genkit reference from supplier flow

### DIFF
--- a/src/ai/flows/analyze-supplier-history.ts
+++ b/src/ai/flows/analyze-supplier-history.ts
@@ -5,7 +5,7 @@
  * @fileOverview An AI agent that analyzes a supplier's history using tools.
  *
  * - analyzeSupplierHistory - A function that performs the analysis.
- * - analyzeSupplierHistoryFlow - The Genkit flow that defines the agent.
+ * - analyzeSupplierHistoryFlow - The flow that defines the agent.
  */
 
 import { ai } from '@/ai/genkit';


### PR DESCRIPTION
## Summary
- remove mention of Genkit from supplier history flow comment

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for configuration)*
- `npm run typecheck` *(fails: numerous TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a9412062d883298976555b68b3e99a