### PR TITLE
chore: neutralize Firestore references

### DIFF
--- a/src/ai/flows/register-customer.ts
+++ b/src/ai/flows/register-customer.ts
@@ -45,7 +45,7 @@ const registerCustomerFlow = ai.defineFlow(
   async (input) => {
     const customerId = input.id;
     
-    // Ensure email is an empty string if not provided, to avoid 'undefined' in Firestore.
+    // Default email to an empty string when missing to keep Netly's data consistent.
     const customerPayload = {
         name: input.name,
         email: input.email || '',

--- a/src/app/cadastros/components/product-list.tsx
+++ b/src/app/cadastros/components/product-list.tsx
@@ -146,7 +146,7 @@ export function ProductList() {
         if (snapshot.data().count > 0) {
             toast({
                 title: 'Banco de dados já populado',
-                description: 'Os dados iniciais já existem no Firestore.',
+                description: 'Os dados iniciais já existem no banco de dados.',
                 variant: 'destructive',
             });
             setIsSeeding(false);


### PR DESCRIPTION
## Summary
- clarify email default comment to align with Netly
- update product seeding description to mention generic database

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint config)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a9428fda308329aaf04eca64510d88