### PR TITLE
Use FileList type in purchase import form

### DIFF
--- a/src/app/compras/components/purchase-import-form.tsx
+++ b/src/app/compras/components/purchase-import-form.tsx
@@ -13,7 +13,10 @@ import { Input } from '@/components/ui/input';
 import { useToast } from '@/hooks/use-toast';
 
 const formSchema = z.object({
-  file: z.any().refine((files) => files?.length > 0, 'Um arquivo é necessário.'),
+  file: z.custom<FileList>(
+    (files) => files instanceof FileList && files.length > 0,
+    { message: 'Um arquivo é necessário.' }
+  ),
 });
 
 export function PurchaseImportForm() {
@@ -23,8 +26,8 @@ export function PurchaseImportForm() {
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
     defaultValues: {
-      file: undefined,
-    }
+      file: new DataTransfer().files,
+    },
   });
 
   const onSubmit = async (data: z.infer<typeof formSchema>) => {


### PR DESCRIPTION
## Summary
- validate purchase import file with `FileList`
- default form value uses an empty `FileList`

## Testing
- `npm run lint` *(fails: How would you like to configure ESLint?)*
- `npm run typecheck` *(fails: numerous TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68a9954cc8588329b911d432013a3782