### PR TITLE
chore: remove debug flag from build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "dev": "next dev --turbopack -p 9002",
-    "build": "next build --debug",
+    "build": "next build",
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit"


### PR DESCRIPTION
## Summary
- simplify Next.js build script by removing `--debug`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires interactive configuration)*
- `npm run typecheck` *(fails: TS2769 and TS2352 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c8a3e734832980a06cbe2777bb69