### PR TITLE
refactor: provide db to collection calls

### DIFF
--- a/src/app/compras/components/manual-purchase-form.tsx
+++ b/src/app/compras/components/manual-purchase-form.tsx
@@ -14,7 +14,7 @@ import { FilePlus2, Trash, CheckCircle2, Loader2 } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 import type { PaymentMethod, SourceAccount, Supplier, Ingredient } from '@/lib/types';
 import { add, addDays, format } from 'date-fns';
-import { collection, getDocs } from '@/lib/netly';
+import { collection, getDocs, db } from '@/lib/netly';
 import { registerManualPurchase } from '@/services/register-manual-purchase';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { Label } from '@/components/ui/label';
@@ -51,8 +51,8 @@ export function ManualPurchaseForm() {
         setIsDataLoading(true);
         try {
             const [suppliersSnapshot, ingredientsSnapshot] = await Promise.all([
-                getDocs(collection('suppliers')) as Promise<Array<Supplier & { id: string }>>,
-                getDocs(collection('ingredients')) as Promise<Array<Ingredient & { id: string }>>,
+                getDocs(collection(db, 'suppliers')) as Promise<Array<Supplier & { id: string }>>,
+                getDocs(collection(db, 'ingredients')) as Promise<Array<Ingredient & { id: string }>>,
             ]);
             setSuppliers(suppliersSnapshot);
             setIngredients(ingredientsSnapshot);

--- a/src/app/compras/components/purchase-history-list.tsx
+++ b/src/app/compras/components/purchase-history-list.tsx
@@ -3,7 +3,7 @@
 'use client';
 
 import { useState, useEffect, useCallback, useMemo } from 'react';
-import { collection, getDocs } from '@/lib/netly';
+import { collection, getDocs, db } from '@/lib/netly';
 import {
   Table,
   TableHeader,
@@ -33,8 +33,8 @@ export function PurchaseHistoryList() {
     setIsLoading(true);
     try {
       const [purchasesList, suppliersList] = await Promise.all([
-        getDocs(collection('purchases')) as Promise<Array<Purchase & { id: string }>>,
-        getDocs(collection('suppliers')) as Promise<Array<Supplier & { id: string }>>,
+        getDocs(collection(db, 'purchases')) as Promise<Array<Purchase & { id: string }>>,
+        getDocs(collection(db, 'suppliers')) as Promise<Array<Supplier & { id: string }>>,
       ]);
 
       const suppliersMap = suppliersList.reduce<Record<string, Supplier>>((acc, doc) => {

--- a/src/app/financeiro/components/accounts-payable.tsx
+++ b/src/app/financeiro/components/accounts-payable.tsx
@@ -3,7 +3,7 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
-import { collection, getDocs } from '@/lib/netly';
+import { collection, getDocs, db } from '@/lib/netly';
 import {
   Table,
   TableHeader,
@@ -42,7 +42,7 @@ export function AccountsPayable() {
     const fetchMovements = useCallback(async () => {
         setIsLoading(true);
         try {
-            const movementList = ((await getDocs(collection('financialMovements'))) as Array<FinancialMovement & { id: string }>)
+            const movementList = ((await getDocs(collection(db, 'financialMovements'))) as Array<FinancialMovement & { id: string }>)
                 .filter(m => m.type === 'expense')
                 .sort((a, b) => new Date(a.dueDate).getTime() - new Date(b.dueDate).getTime());
             setMovements(movementList);

--- a/src/app/financeiro/components/accounts-receivable.tsx
+++ b/src/app/financeiro/components/accounts-receivable.tsx
@@ -2,7 +2,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { collection, getDocs } from '@/lib/netly';
+import { collection, getDocs, db } from '@/lib/netly';
 import {
   Table,
   TableHeader,
@@ -29,7 +29,7 @@ export function AccountsReceivable() {
     const fetchReceivables = async () => {
       setIsLoading(true);
       try {
-        const accountsList = ((await getDocs(collection('customers'))) as Array<Customer & { id: string }>).
+        const accountsList = ((await getDocs(collection(db, 'customers'))) as Array<Customer & { id: string }>).
           filter(c => c.pendingAmount > 0);
         setAccounts(accountsList);
       } catch (error) {

--- a/src/app/financeiro/components/employee-financial-report.tsx
+++ b/src/app/financeiro/components/employee-financial-report.tsx
@@ -3,7 +3,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { collection, getDocs } from '@/lib/netly';
+import { collection, getDocs, db } from '@/lib/netly';
 import type { FinancialMovement, Employee } from '@/lib/types';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
 import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from '@/components/ui/table';
@@ -31,7 +31,7 @@ export function EmployeeFinancialReport() {
 
   useEffect(() => {
     const fetchEmployees = async () => {
-      const snap = (await getDocs(collection('employees'))) as Array<Employee & { id: string }>;
+      const snap = (await getDocs(collection(db, 'employees'))) as Array<Employee & { id: string }>;
       setEmployees(snap);
     };
     fetchEmployees();
@@ -40,7 +40,7 @@ export function EmployeeFinancialReport() {
   const fetchReport = async () => {
     setIsLoading(true);
     try {
-      const movements = ((await getDocs(collection('financialMovements'))) as Array<FinancialMovement & { id: string }>)
+      const movements = ((await getDocs(collection(db, 'financialMovements'))) as Array<FinancialMovement & { id: string }>)
         .filter(
           m =>
             !!m.paymentDate &&

--- a/src/app/financeiro/components/latest-transactions.tsx
+++ b/src/app/financeiro/components/latest-transactions.tsx
@@ -3,7 +3,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { collection, getDocs } from '@/lib/netly';
+import { collection, getDocs, db } from '@/lib/netly';
 import {
   Table,
   TableHeader,
@@ -27,7 +27,7 @@ export function LatestTransactions() {
     const fetchTransactions = async () => {
       setIsLoading(true);
       try {
-        const transactions = ((await getDocs(collection('financialMovements'))) as Array<FinancialMovement & { id: string }>)
+        const transactions = ((await getDocs(collection(db, 'financialMovements'))) as Array<FinancialMovement & { id: string }>)
           .filter(t => t.status === 'paid')
           .sort((a, b) => (b.paymentDate || '').localeCompare(a.paymentDate || ''))
           .slice(0, 5);

--- a/src/app/financeiro/components/transactions-list.tsx
+++ b/src/app/financeiro/components/transactions-list.tsx
@@ -3,7 +3,7 @@
 'use client';
 
 import { useState, useMemo, useEffect } from 'react';
-import { collection, getDocs } from '@/lib/netly';
+import { collection, getDocs, db } from '@/lib/netly';
 import {
   Table,
   TableHeader,
@@ -35,7 +35,7 @@ export function TransactionsList({ accountFilter }: TransactionsListProps) {
         const fetchTransactions = async () => {
             setIsLoading(true);
             try {
-                const allMovements = ((await getDocs(collection('financialMovements'))) as Array<FinancialMovement & { id: string }>)
+                const allMovements = ((await getDocs(collection(db, 'financialMovements'))) as Array<FinancialMovement & { id: string }>)
                     .filter(doc => doc.status === 'paid')
                     .sort((a, b) => (b.paymentDate || '').localeCompare(a.paymentDate || ''));
 

--- a/src/app/financeiro/despesas/nova/page.tsx
+++ b/src/app/financeiro/despesas/nova/page.tsx
@@ -40,7 +40,7 @@ import { CheckCircle2, Loader2 } from 'lucide-react';
 import Link from 'next/link';
 import { useState, useEffect } from 'react';
 import { registerExpense } from '@/services/register-expense';
-import { collection, getDocs } from '@/lib/netly';
+import { collection, getDocs, db } from '@/lib/netly';
 import type { Employee } from '@/lib/types';
 
 
@@ -86,7 +86,7 @@ export default function NewExpensePage() {
     const fetchEmployees = async () => {
         if (shouldShowEmployeeField) {
             try {
-                const employeesSnapshot = (await getDocs(collection('employees'))) as Array<Employee & { id: string }>;
+                const employeesSnapshot = (await getDocs(collection(db, 'employees'))) as Array<Employee & { id: string }>;
                 setEmployees(employeesSnapshot);
             } catch (error) {
                  toast({ title: "Erro ao buscar funcionários", variant: 'destructive' });

--- a/src/app/operacoes/page.tsx
+++ b/src/app/operacoes/page.tsx
@@ -7,7 +7,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { PlusCircle, ShoppingCart, Package, RefreshCw, Eye, ShoppingBag, SlidersHorizontal } from 'lucide-react';
 import React, { useState, useEffect, useCallback } from 'react';
-import { collection, getDocs } from '@/lib/netly';
+import { collection, getDocs, db } from '@/lib/netly';
 import type { Product, Customer, Ingredient } from '@/lib/types';
 import { useToast } from '@/hooks/use-toast';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
@@ -25,8 +25,8 @@ export default function OperacoesPage() {
   const fetchData = useCallback(async () => {
     try {
         const [productList, ingredientList] = await Promise.all([
-            getDocs(collection('products')) as Promise<Array<Product & { id: string }>>,
-            getDocs(collection('ingredients')) as Promise<Array<Ingredient & { id: string }>>,
+            getDocs(collection(db, 'products')) as Promise<Array<Product & { id: string }>>,
+            getDocs(collection(db, 'ingredients')) as Promise<Array<Ingredient & { id: string }>>,
         ]);
         setProducts(productList);
         setIngredients(ingredientList);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,7 +11,7 @@ import { QuickActions } from '@/components/dashboard/quick-actions';
 import { Alerts } from '@/components/dashboard/alerts';
 import { BillingChart } from '@/components/dashboard/billing-chart';
 import { ExpenseChart } from '@/components/dashboard/expense-chart';
-import { collection, getDocs } from '@/lib/netly';
+import { collection, getDocs, db } from '@/lib/netly';
 import type { FinancialMovement, Ingredient } from '@/lib/types';
 import { StatCard } from '@/components/stat-card';
 import { LatestTransactions } from '@/components/dashboard/latest-transactions';
@@ -25,8 +25,8 @@ async function getDashboardData() {
     const todayStr = format(new Date(), 'yyyy-MM-dd');
 
     const [movements, ingredients] = await Promise.all([
-        getDocs(collection('financialMovements')) as Promise<Array<FinancialMovement & { id: string }>>,
-        getDocs(collection('ingredients')) as Promise<Array<Ingredient & { id: string }>>,
+        getDocs(collection(db, 'financialMovements')) as Promise<Array<FinancialMovement & { id: string }>>,
+        getDocs(collection(db, 'ingredients')) as Promise<Array<Ingredient & { id: string }>>,
     ]);
 
     const paidToday = movements.filter(m => m.paymentDate === todayStr && m.status === 'paid');

--- a/src/app/pdv/page.tsx
+++ b/src/app/pdv/page.tsx
@@ -3,7 +3,7 @@
 'use client';
 
 import { useState, useEffect, useCallback, useMemo } from 'react';
-import { collection, getDocs } from '@/lib/netly';
+import { collection, getDocs, db } from '@/lib/netly';
 import type { Product, Customer } from '@/lib/types';
 import { useToast } from '@/hooks/use-toast';
 import { Button } from '@/components/ui/button';
@@ -33,8 +33,8 @@ export default function PdvPage() {
     setIsLoading(true);
     try {
       const [productList, customerList] = await Promise.all([
-        getDocs(collection('products')) as Promise<Array<Product & { id: string }>>,
-        getDocs(collection('customers')) as Promise<Array<Customer & { id: string }>>,
+        getDocs(collection(db, 'products')) as Promise<Array<Product & { id: string }>>,
+        getDocs(collection(db, 'customers')) as Promise<Array<Customer & { id: string }>>,
       ]);
       setProducts(productList);
       setCustomers(customerList);

--- a/src/app/trocas/page.tsx
+++ b/src/app/trocas/page.tsx
@@ -9,7 +9,7 @@ import { PlusCircle, Loader2 } from 'lucide-react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
 import { useToast } from '@/hooks/use-toast';
 import type { Product, Exchange, Customer } from '@/lib/types';
-import { collection, getDocs } from '@/lib/netly';
+import { collection, getDocs, db } from '@/lib/netly';
 import { ExchangeForm } from './components/exchange-form';
 import { ExchangeHistory } from './components/exchange-history';
 
@@ -26,9 +26,9 @@ export default function TrocasPage() {
     setIsLoading(true);
     try {
       const [productList, exchangeListRaw, customerList] = await Promise.all([
-        getDocs(collection('products')) as Promise<Array<Product & { id: string }>>,
-        getDocs(collection('exchanges')) as Promise<Array<Exchange & { id: string }>>,
-        getDocs(collection('customers')) as Promise<Array<Customer & { id: string }>>,
+        getDocs(collection(db, 'products')) as Promise<Array<Product & { id: string }>>,
+        getDocs(collection(db, 'exchanges')) as Promise<Array<Exchange & { id: string }>>,
+        getDocs(collection(db, 'customers')) as Promise<Array<Customer & { id: string }>>,
       ]);
 
       const productsMap = new Map(productList.map(p => [p.id, p]));

--- a/src/app/vendas/components/sales-history.tsx
+++ b/src/app/vendas/components/sales-history.tsx
@@ -15,7 +15,7 @@ import { ArrowRight, Loader2, ShoppingBag, Truck } from 'lucide-react';
 import type { Sale } from '@/lib/types';
 import { Badge } from '@/components/ui/badge';
 import { useEffect, useState } from 'react';
-import { collection, getDocs } from '@/lib/netly';
+import { collection, getDocs, db } from '@/lib/netly';
 import { useToast } from '@/hooks/use-toast';
 
 export function SalesHistory() {
@@ -27,7 +27,7 @@ export function SalesHistory() {
         const fetchData = async () => {
             setIsLoading(true);
             try {
-                const salesList = (await getDocs(collection('sales'))) as Array<Sale & { id: string }>;
+                const salesList = (await getDocs(collection(db, 'sales'))) as Array<Sale & { id: string }>;
                 setSales(salesList.sort((a, b) => b.date.localeCompare(a.date)));
             } catch (error) {
                 toast({

--- a/src/app/vendas/page.tsx
+++ b/src/app/vendas/page.tsx
@@ -9,7 +9,7 @@ import { PlusCircle, Loader2 } from 'lucide-react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
 import { useToast } from '@/hooks/use-toast';
 import type { Product, Customer, Salesperson } from '@/lib/types';
-import { collection, getDocs } from '@/lib/netly';
+import { collection, getDocs, db } from '@/lib/netly';
 import { ExternalSaleForm } from './components/external-sale-form';
 import { SalesHistory } from './components/sales-history';
 
@@ -26,9 +26,9 @@ export default function VendasExternasPage() {
     setIsLoading(true);
     try {
       const [productList, customerList, salespersonList] = await Promise.all([
-        getDocs(collection('products')) as Promise<Array<Product & { id: string }>>,
-        getDocs(collection('customers')) as Promise<Array<Customer & { id: string }>>,
-        getDocs(collection('salespeople')) as Promise<Array<Salesperson & { id: string }>>,
+        getDocs(collection(db, 'products')) as Promise<Array<Product & { id: string }>>,
+        getDocs(collection(db, 'customers')) as Promise<Array<Customer & { id: string }>>,
+        getDocs(collection(db, 'salespeople')) as Promise<Array<Salesperson & { id: string }>>,
       ]);
 
       setProducts(productList);


### PR DESCRIPTION
## Summary
- import db and pass as first arg to collection calls across app

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint setup)*
- `npm run typecheck` *(fails: Argument of type 'string' is not assignable to parameter of type 'NetlyCollectionReference')*


------
https://chatgpt.com/codex/tasks/task_e_68a9cc5f5a1c8329ab82d734fe0ebbfa