### PR TITLE
refactor: use typed getDoc snapshots

### DIFF
--- a/src/services/adjust-stock.ts
+++ b/src/services/adjust-stock.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { z } from 'zod';
-import { doc, getDoc, updateDoc, increment } from '@/lib/netly';
+import { db, doc, getDoc, updateDoc, increment } from '@/lib/netly';
 import type { Product, Ingredient } from '@/lib/types';
 
 const AdjustStockInputSchema = z.object({
@@ -18,10 +18,11 @@ export async function adjustStock(
 ): Promise<{ message: string }> {
   const { itemId, itemType, adjustmentType, quantity } = input;
   const collectionPath = itemType === 'product' ? 'products' : 'ingredients';
-  const itemRef = doc(collectionPath, itemId);
+  const itemRef = doc(db, collectionPath, itemId);
 
-  const item = (await getDoc(itemRef)) as (Product | Ingredient) | null;
-  if (!item) {
+  const itemSnap = await getDoc<Product | Ingredient>(itemRef);
+  const item = itemSnap.data();
+  if (!itemSnap.exists()) {
     throw new Error(`Item with ID ${itemId} not found in ${collectionPath}.`);
   }
 

--- a/src/services/register-exchange.ts
+++ b/src/services/register-exchange.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { z } from 'zod';
-import { doc, getDoc, updateDoc, addDoc, increment } from '@/lib/netly';
+import { db, doc, getDoc, updateDoc, addDoc, increment } from '@/lib/netly';
 import type { Exchange, Product } from '@/lib/types';
 import { format } from 'date-fns';
 
@@ -19,22 +19,25 @@ export async function registerExchange(
 ): Promise<{ message: string; exchangeId: string }> {
   const { customerId, returnedProductId, newProductId, reason, returnedProductStatus } = input;
 
-  const newProductRef = doc('products', newProductId);
-  const newProduct = (await getDoc(newProductRef)) as Product | null;
-  if (!newProduct || newProduct.stock < 1) {
+  const newProductRef = doc(db, 'products', newProductId);
+  const newProductSnap = await getDoc<Product>(newProductRef);
+  const newProduct = newProductSnap.data();
+  if (!newProductSnap.exists() || newProduct.stock < 1) {
     throw new Error(
-      `Estoque insuficiente para o produto de troca: ${newProduct?.name || 'ID ' + newProductId}`,
+      `Estoque insuficiente para o produto de troca: ${
+        newProductSnap.exists() ? newProduct.name : 'ID ' + newProductId
+      }`,
     );
   }
   await updateDoc(newProductRef, { stock: increment(-1) });
 
   if (returnedProductStatus === 'restock') {
-    const returnedProductRef = doc('products', returnedProductId);
+    const returnedProductRef = doc(db, 'products', returnedProductId);
     await updateDoc(returnedProductRef, { stock: increment(1) });
   }
 
   if (customerId && customerId !== 'none') {
-    const customerRef = doc('customers', customerId);
+    const customerRef = doc(db, 'customers', customerId);
     await updateDoc(customerRef, { exchanges: increment(1) });
   }
 

--- a/src/services/register-manual-purchase.ts
+++ b/src/services/register-manual-purchase.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { z } from 'zod';
-import { addDoc, doc, getDoc, updateDoc, increment } from '@/lib/netly';
+import { db, addDoc, doc, getDoc, updateDoc, increment } from '@/lib/netly';
 import type { Purchase, FinancialMovement, Supplier, Ingredient, SourceAccount } from '@/lib/types';
 import { format, addMonths } from 'date-fns';
 
@@ -27,8 +27,9 @@ export type RegisterManualPurchaseInput = z.infer<typeof RegisterManualPurchaseI
 export async function registerManualPurchase(
   input: RegisterManualPurchaseInput,
 ): Promise<{ purchaseId: string; message: string }> {
-  const supplier = (await getDoc(doc('suppliers', input.supplierId))) as Supplier | null;
-  if (!supplier) {
+  const supplierSnap = await getDoc<Supplier>(doc(db, 'suppliers', input.supplierId));
+  const supplier = supplierSnap.data();
+  if (!supplierSnap.exists()) {
     throw new Error('Fornecedor não encontrado.');
   }
 
@@ -42,8 +43,11 @@ export async function registerManualPurchase(
   };
 
   for (const item of input.items) {
-    const ingredient = (await getDoc(doc('ingredients', item.ingredientId))) as Ingredient | null;
-    if (!ingredient) {
+    const ingredientSnap = await getDoc<Ingredient>(
+      doc(db, 'ingredients', item.ingredientId),
+    );
+    const ingredient = ingredientSnap.data();
+    if (!ingredientSnap.exists()) {
       throw new Error(`Insumo com ID ${item.ingredientId} não encontrado.`);
     }
 
@@ -57,7 +61,7 @@ export async function registerManualPurchase(
         ? (oldStock * oldCost + newQuantity * newPrice) / newTotalStock
         : newPrice;
 
-    await updateDoc(doc('ingredients', item.ingredientId), {
+    await updateDoc(doc(db, 'ingredients', item.ingredientId), {
       stock: increment(newQuantity),
       cost: newAverageCost,
     });

--- a/src/services/register-production.ts
+++ b/src/services/register-production.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { z } from 'zod';
-import { doc, getDoc, updateDoc, increment } from '@/lib/netly';
+import { db, doc, getDoc, updateDoc, increment } from '@/lib/netly';
 import type { Recipe, Ingredient, Product } from '@/lib/types';
 
 const RegisterProductionInputSchema = z.object({
@@ -15,19 +15,24 @@ export async function registerProduction(
 ): Promise<{ message: string }> {
   const { productId, quantity } = input;
 
-  const product = (await getDoc(doc('products', productId))) as Product | null;
-  if (!product) {
+  const productSnap = await getDoc<Product>(doc(db, 'products', productId));
+  const product = productSnap.data();
+  if (!productSnap.exists()) {
     throw new Error(`Produto com ID ${productId} não encontrado.`);
   }
 
-  const recipe = (await getDoc(doc('recipes', productId))) as Recipe | null;
-  if (!recipe) {
+  const recipeSnap = await getDoc<Recipe>(doc(db, 'recipes', productId));
+  const recipe = recipeSnap.data();
+  if (!recipeSnap.exists()) {
     throw new Error(`Ficha técnica para o produto ${product.name} não encontrada.`);
   }
 
   for (const item of recipe.items) {
-    const ingredient = (await getDoc(doc('ingredients', item.ingredientId))) as Ingredient | null;
-    if (!ingredient) {
+    const ingredientSnap = await getDoc<Ingredient>(
+      doc(db, 'ingredients', item.ingredientId),
+    );
+    const ingredient = ingredientSnap.data();
+    if (!ingredientSnap.exists()) {
       throw new Error(`Insumo com ID ${item.ingredientId} da receita não foi encontrado.`);
     }
     const currentStock = ingredient.stock || 0;
@@ -37,10 +42,12 @@ export async function registerProduction(
         `Estoque insuficiente para o insumo "${ingredient.name}". Necessário: ${requiredStock}${ingredient.unitOfMeasure}, Disponível: ${currentStock}${ingredient.unitOfMeasure}`,
       );
     }
-    await updateDoc(doc('ingredients', item.ingredientId), { stock: increment(-requiredStock) });
+    await updateDoc(doc(db, 'ingredients', item.ingredientId), {
+      stock: increment(-requiredStock),
+    });
   }
 
-  await updateDoc(doc('products', productId), {
+  await updateDoc(doc(db, 'products', productId), {
     stock: increment(quantity),
     produced: increment(quantity),
   });

--- a/src/services/register-sale.ts
+++ b/src/services/register-sale.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { z } from 'zod';
-import { doc, getDoc, updateDoc, addDoc, increment } from '@/lib/netly';
+import { db, doc, getDoc, updateDoc, addDoc, increment } from '@/lib/netly';
 import type { Product, FinancialMovement, SourceAccount, Sale, SaleItem, SaleChannel } from '@/lib/types';
 import { format } from 'date-fns';
 
@@ -49,15 +49,20 @@ export async function registerSale(
 
   if (isConcluded) {
     for (const item of items) {
-      const product = (await getDoc(doc('products', item.productId))) as Product | null;
-      if (!product) {
+      const productSnap = await getDoc<Product>(
+        doc(db, 'products', item.productId),
+      );
+      const product = productSnap.data();
+      if (!productSnap.exists()) {
         throw new Error(`Produto ${item.productName} não encontrado.`);
       }
       const currentStock = product.stock || 0;
       if (currentStock < item.quantity) {
-        throw new Error(`Estoque insuficiente para ${product.name}. Disponível: ${currentStock}, Solicitado: ${item.quantity}`);
+        throw new Error(
+          `Estoque insuficiente para ${product.name}. Disponível: ${currentStock}, Solicitado: ${item.quantity}`,
+        );
       }
-      await updateDoc(doc('products', item.productId), {
+      await updateDoc(doc(db, 'products', item.productId), {
         stock: increment(-item.quantity),
         sold: increment(item.quantity),
       });
@@ -103,7 +108,7 @@ export async function registerSale(
     await addDoc('financialMovements', financialMovement);
 
     if (customerId) {
-      await updateDoc(doc('customers', customerId), {
+      await updateDoc(doc(db, 'customers', customerId), {
         pendingAmount: isSaleOnCredit ? increment(totalAmount) : increment(0),
         lastPurchaseDate: format(today, 'dd/MM/yyyy'),
         totalOrders: increment(1),

--- a/src/services/settle-customer-payment.ts
+++ b/src/services/settle-customer-payment.ts
@@ -1,8 +1,9 @@
 'use server';
 
 import { z } from 'zod';
-import { doc, getDoc, updateDoc, increment } from '@/lib/netly';
+import { db, doc, getDoc, updateDoc, increment } from '@/lib/netly';
 import { format } from 'date-fns';
+import type { Customer } from '@/lib/types';
 
 const SettleCustomerPaymentInputSchema = z.object({
   movementId: z.string().describe('The ID of the financial movement to be settled.'),
@@ -16,9 +17,10 @@ export async function settleCustomerPayment(
 ): Promise<{ message: string }> {
   const { movementId, customerId, amount } = input;
 
-  const movementRef = doc('financialMovements', movementId);
-  const movement = (await getDoc(movementRef)) as { status: string } | null;
-  if (!movement) {
+  const movementRef = doc(db, 'financialMovements', movementId);
+  const movementSnap = await getDoc<{ status: string }>(movementRef);
+  const movement = movementSnap.data();
+  if (!movementSnap.exists()) {
     throw new Error(`Movimentação financeira ${movementId} não encontrada.`);
   }
   if (movement.status === 'paid') {
@@ -30,9 +32,10 @@ export async function settleCustomerPayment(
     paymentDate: format(new Date(), 'yyyy-MM-dd'),
   });
 
-  const customerRef = doc('customers', customerId);
-  const customer = await getDoc(customerRef);
-  if (!customer) {
+  const customerRef = doc(db, 'customers', customerId);
+  const customerSnap = await getDoc<Customer>(customerRef);
+  const customer = customerSnap.data();
+  if (!customerSnap.exists()) {
     throw new Error(`Cliente ${customerId} não encontrado.`);
   }
 

--- a/src/services/settle-expense.ts
+++ b/src/services/settle-expense.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { z } from 'zod';
-import { doc, getDoc, updateDoc } from '@/lib/netly';
+import { db, doc, getDoc, updateDoc } from '@/lib/netly';
 import { format } from 'date-fns';
 
 const SettleExpenseInputSchema = z.object({
@@ -14,9 +14,10 @@ export async function settleExpense(
 ): Promise<{ message: string }> {
   const { movementId } = input;
 
-  const movementRef = doc('financialMovements', movementId);
-  const movement = (await getDoc(movementRef)) as { status: string } | null;
-  if (!movement) {
+  const movementRef = doc(db, 'financialMovements', movementId);
+  const movementSnap = await getDoc<{ status: string }>(movementRef);
+  const movement = movementSnap.data();
+  if (!movementSnap.exists()) {
     throw new Error(`Movimentação financeira ${movementId} não encontrada.`);
   }
   if (movement.status === 'paid') {


### PR DESCRIPTION
## Summary
- refactor service getDoc calls to typed snapshots with exists checks

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires ESLint configuration)*
- `npm run typecheck` *(fails: Expected 2 arguments, but got 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a9cc67cfac8329ad568d501312f185