### PR TITLE
refactor: pass db to document refs

### DIFF
--- a/src/services/adjust-stock.ts
+++ b/src/services/adjust-stock.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { z } from 'zod';
-import { doc, getDoc, updateDoc, increment } from '@/lib/netly';
+import { db, doc, getDoc, updateDoc, increment } from '@/lib/netly';
 import type { Product, Ingredient } from '@/lib/types';
 
 const AdjustStockInputSchema = z.object({
@@ -18,7 +18,7 @@ export async function adjustStock(
 ): Promise<{ message: string }> {
   const { itemId, itemType, adjustmentType, quantity } = input;
   const collectionPath = itemType === 'product' ? 'products' : 'ingredients';
-  const itemRef = doc(collectionPath, itemId);
+  const itemRef = doc(db, collectionPath, itemId);
 
   const item = (await getDoc(itemRef)) as (Product | Ingredient) | null;
   if (!item) {

--- a/src/services/register-customer.ts
+++ b/src/services/register-customer.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { z } from 'zod';
-import { addDoc, updateDoc, doc } from '@/lib/netly';
+import { db, addDoc, updateDoc, doc } from '@/lib/netly';
 import type { Customer } from '@/lib/types';
 import { format } from 'date-fns';
 
@@ -34,7 +34,7 @@ export async function registerCustomer(
   };
 
   if (customerId) {
-    const customerRef = doc('customers', customerId);
+    const customerRef = doc(db, 'customers', customerId);
     await updateDoc(customerRef, customerPayload);
     return { customerId, message: `Cliente "${input.name}" atualizado com sucesso.` };
   }

--- a/src/services/register-employee.ts
+++ b/src/services/register-employee.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { z } from 'zod';
-import { addDoc, updateDoc, doc } from '@/lib/netly';
+import { db, addDoc, updateDoc, doc } from '@/lib/netly';
 import type { Employee } from '@/lib/types';
 
 const RegisterEmployeeInputSchema = z.object({
@@ -21,7 +21,7 @@ export async function registerEmployee(
   const employeePayload = { ...input };
 
   if (employeeId) {
-    const employeeRef = doc('employees', employeeId);
+    const employeeRef = doc(db, 'employees', employeeId);
     await updateDoc(employeeRef, employeePayload);
     return { employeeId, message: `Funcionário "${input.name}" atualizado com sucesso.` };
   }

--- a/src/services/register-exchange.ts
+++ b/src/services/register-exchange.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { z } from 'zod';
-import { doc, getDoc, updateDoc, addDoc, increment } from '@/lib/netly';
+import { db, doc, getDoc, updateDoc, addDoc, increment } from '@/lib/netly';
 import type { Exchange, Product } from '@/lib/types';
 import { format } from 'date-fns';
 
@@ -19,7 +19,7 @@ export async function registerExchange(
 ): Promise<{ message: string; exchangeId: string }> {
   const { customerId, returnedProductId, newProductId, reason, returnedProductStatus } = input;
 
-  const newProductRef = doc('products', newProductId);
+  const newProductRef = doc(db, 'products', newProductId);
   const newProduct = (await getDoc(newProductRef)) as Product | null;
   if (!newProduct || newProduct.stock < 1) {
     throw new Error(
@@ -29,12 +29,12 @@ export async function registerExchange(
   await updateDoc(newProductRef, { stock: increment(-1) });
 
   if (returnedProductStatus === 'restock') {
-    const returnedProductRef = doc('products', returnedProductId);
+    const returnedProductRef = doc(db, 'products', returnedProductId);
     await updateDoc(returnedProductRef, { stock: increment(1) });
   }
 
   if (customerId && customerId !== 'none') {
-    const customerRef = doc('customers', customerId);
+    const customerRef = doc(db, 'customers', customerId);
     await updateDoc(customerRef, { exchanges: increment(1) });
   }
 

--- a/src/services/register-manual-purchase.ts
+++ b/src/services/register-manual-purchase.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { z } from 'zod';
-import { addDoc, doc, getDoc, updateDoc, increment } from '@/lib/netly';
+import { db, addDoc, doc, getDoc, updateDoc, increment } from '@/lib/netly';
 import type { Purchase, FinancialMovement, Supplier, Ingredient, SourceAccount } from '@/lib/types';
 import { format, addMonths } from 'date-fns';
 
@@ -27,7 +27,7 @@ export type RegisterManualPurchaseInput = z.infer<typeof RegisterManualPurchaseI
 export async function registerManualPurchase(
   input: RegisterManualPurchaseInput,
 ): Promise<{ purchaseId: string; message: string }> {
-  const supplier = (await getDoc(doc('suppliers', input.supplierId))) as Supplier | null;
+  const supplier = (await getDoc(doc(db, 'suppliers', input.supplierId))) as Supplier | null;
   if (!supplier) {
     throw new Error('Fornecedor não encontrado.');
   }
@@ -42,7 +42,7 @@ export async function registerManualPurchase(
   };
 
   for (const item of input.items) {
-    const ingredient = (await getDoc(doc('ingredients', item.ingredientId))) as Ingredient | null;
+    const ingredient = (await getDoc(doc(db, 'ingredients', item.ingredientId))) as Ingredient | null;
     if (!ingredient) {
       throw new Error(`Insumo com ID ${item.ingredientId} não encontrado.`);
     }
@@ -57,7 +57,7 @@ export async function registerManualPurchase(
         ? (oldStock * oldCost + newQuantity * newPrice) / newTotalStock
         : newPrice;
 
-    await updateDoc(doc('ingredients', item.ingredientId), {
+    await updateDoc(doc(db, 'ingredients', item.ingredientId), {
       stock: increment(newQuantity),
       cost: newAverageCost,
     });

--- a/src/services/register-production.ts
+++ b/src/services/register-production.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { z } from 'zod';
-import { doc, getDoc, updateDoc, increment } from '@/lib/netly';
+import { db, doc, getDoc, updateDoc, increment } from '@/lib/netly';
 import type { Recipe, Ingredient, Product } from '@/lib/types';
 
 const RegisterProductionInputSchema = z.object({
@@ -15,18 +15,18 @@ export async function registerProduction(
 ): Promise<{ message: string }> {
   const { productId, quantity } = input;
 
-  const product = (await getDoc(doc('products', productId))) as Product | null;
+  const product = (await getDoc(doc(db, 'products', productId))) as Product | null;
   if (!product) {
     throw new Error(`Produto com ID ${productId} não encontrado.`);
   }
 
-  const recipe = (await getDoc(doc('recipes', productId))) as Recipe | null;
+  const recipe = (await getDoc(doc(db, 'recipes', productId))) as Recipe | null;
   if (!recipe) {
     throw new Error(`Ficha técnica para o produto ${product.name} não encontrada.`);
   }
 
   for (const item of recipe.items) {
-    const ingredient = (await getDoc(doc('ingredients', item.ingredientId))) as Ingredient | null;
+    const ingredient = (await getDoc(doc(db, 'ingredients', item.ingredientId))) as Ingredient | null;
     if (!ingredient) {
       throw new Error(`Insumo com ID ${item.ingredientId} da receita não foi encontrado.`);
     }
@@ -37,10 +37,10 @@ export async function registerProduction(
         `Estoque insuficiente para o insumo "${ingredient.name}". Necessário: ${requiredStock}${ingredient.unitOfMeasure}, Disponível: ${currentStock}${ingredient.unitOfMeasure}`,
       );
     }
-    await updateDoc(doc('ingredients', item.ingredientId), { stock: increment(-requiredStock) });
+    await updateDoc(doc(db, 'ingredients', item.ingredientId), { stock: increment(-requiredStock) });
   }
 
-  await updateDoc(doc('products', productId), {
+  await updateDoc(doc(db, 'products', productId), {
     stock: increment(quantity),
     produced: increment(quantity),
   });

--- a/src/services/register-sale.ts
+++ b/src/services/register-sale.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { z } from 'zod';
-import { doc, getDoc, updateDoc, addDoc, increment } from '@/lib/netly';
+import { db, doc, getDoc, updateDoc, addDoc, increment } from '@/lib/netly';
 import type { Product, FinancialMovement, SourceAccount, Sale, SaleItem, SaleChannel } from '@/lib/types';
 import { format } from 'date-fns';
 
@@ -49,7 +49,7 @@ export async function registerSale(
 
   if (isConcluded) {
     for (const item of items) {
-      const product = (await getDoc(doc('products', item.productId))) as Product | null;
+      const product = (await getDoc(doc(db, 'products', item.productId))) as Product | null;
       if (!product) {
         throw new Error(`Produto ${item.productName} não encontrado.`);
       }
@@ -57,7 +57,7 @@ export async function registerSale(
       if (currentStock < item.quantity) {
         throw new Error(`Estoque insuficiente para ${product.name}. Disponível: ${currentStock}, Solicitado: ${item.quantity}`);
       }
-      await updateDoc(doc('products', item.productId), {
+      await updateDoc(doc(db, 'products', item.productId), {
         stock: increment(-item.quantity),
         sold: increment(item.quantity),
       });
@@ -103,7 +103,7 @@ export async function registerSale(
     await addDoc('financialMovements', financialMovement);
 
     if (customerId) {
-      await updateDoc(doc('customers', customerId), {
+      await updateDoc(doc(db, 'customers', customerId), {
         pendingAmount: isSaleOnCredit ? increment(totalAmount) : increment(0),
         lastPurchaseDate: format(today, 'dd/MM/yyyy'),
         totalOrders: increment(1),

--- a/src/services/settle-customer-payment.ts
+++ b/src/services/settle-customer-payment.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { z } from 'zod';
-import { doc, getDoc, updateDoc, increment } from '@/lib/netly';
+import { db, doc, getDoc, updateDoc, increment } from '@/lib/netly';
 import { format } from 'date-fns';
 
 const SettleCustomerPaymentInputSchema = z.object({
@@ -16,7 +16,7 @@ export async function settleCustomerPayment(
 ): Promise<{ message: string }> {
   const { movementId, customerId, amount } = input;
 
-  const movementRef = doc('financialMovements', movementId);
+  const movementRef = doc(db, 'financialMovements', movementId);
   const movement = (await getDoc(movementRef)) as { status: string } | null;
   if (!movement) {
     throw new Error(`Movimentação financeira ${movementId} não encontrada.`);
@@ -30,7 +30,7 @@ export async function settleCustomerPayment(
     paymentDate: format(new Date(), 'yyyy-MM-dd'),
   });
 
-  const customerRef = doc('customers', customerId);
+  const customerRef = doc(db, 'customers', customerId);
   const customer = await getDoc(customerRef);
   if (!customer) {
     throw new Error(`Cliente ${customerId} não encontrado.`);

--- a/src/services/settle-expense.ts
+++ b/src/services/settle-expense.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { z } from 'zod';
-import { doc, getDoc, updateDoc } from '@/lib/netly';
+import { db, doc, getDoc, updateDoc } from '@/lib/netly';
 import { format } from 'date-fns';
 
 const SettleExpenseInputSchema = z.object({
@@ -14,7 +14,7 @@ export async function settleExpense(
 ): Promise<{ message: string }> {
   const { movementId } = input;
 
-  const movementRef = doc('financialMovements', movementId);
+  const movementRef = doc(db, 'financialMovements', movementId);
   const movement = (await getDoc(movementRef)) as { status: string } | null;
   if (!movement) {
     throw new Error(`Movimentação financeira ${movementId} não encontrada.`);


### PR DESCRIPTION
## Summary
- supply `db` from `@/lib/netly` in service modules
- pass `db` as the first argument to `doc` for all document references

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint setup)*
- `npm run typecheck` *(fails: TS2322, TS2352, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a9cc61b8048329ac9169e2f243a588