### PR TITLE
refactor: remove PageProps augmentation

### DIFF
--- a/src/app/cadastros/fornecedores/[id]/page.tsx
+++ b/src/app/cadastros/fornecedores/[id]/page.tsx
@@ -4,7 +4,6 @@ import type { Supplier, Purchase, FinancialMovement } from '@/lib/types';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { ChevronLeft } from 'lucide-react';
-import type { PageProps } from 'next';
 
 // Revalidate this page at most once every hour
 export const revalidate = 3600;
@@ -47,7 +46,11 @@ async function getSupplierData(id: string) {
 }
 
 
-export default async function SupplierDetailPage({ params }: PageProps<{ id: string }>) {
+export default async function SupplierDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
   const { id } = await params;
   const data = await getSupplierData(id);
 

--- a/src/types/next.d.ts
+++ b/src/types/next.d.ts
@@ -1,7 +1,0 @@
-import 'next';
-
-declare module 'next' {
-  export interface PageProps<T = {}> {
-    params: Promise<T>;
-  }
-}


### PR DESCRIPTION
## Summary
- remove custom `PageProps` augmentation for Next.js 15
- explicitly type route `params` as `Promise` in supplier details page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompts for ESLint config)*
- `npm run typecheck` *(fails: TS2769 and TS2322 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a9d1ea9f148329bd52789a6bbc07b9