### PR TITLE
docs: add environment variables section

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,8 @@ To get started, take a look at `src/app/page.tsx`.
 4. Faça commit e push para a branch principal para disparar o deploy.
 5. Utilize o painel da Netly para acompanhar logs e reimplantações.
 
+## Environment Variables
+
+- `NEXT_PUBLIC_NETLY_API_URL` (**required**): Base URL for the Netly API used by the application.
+- `NEXT_PUBLIC_NETLY_API_KEY` (optional): API key for authenticating requests when required.
+


### PR DESCRIPTION
## Summary
- document environment variables used by Netly starter

## Testing
- `npm run lint` (fails: asks for ESLint configuration)
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a9d6d7103c8329a13d4fc7a7491eb7