### PR TITLE
chore: force dynamic supplier details

### DIFF
--- a/src/app/cadastros/fornecedores/[id]/page.tsx
+++ b/src/app/cadastros/fornecedores/[id]/page.tsx
@@ -7,6 +7,7 @@ import { ChevronLeft } from 'lucide-react';
 
 // Revalidate this page at most once every hour
 export const revalidate = 3600;
+export const dynamic = 'force-dynamic';
 
 async function getSupplierData(id: string) {
     const supplierDocRef = doc(db, 'suppliers', id);
@@ -84,17 +85,4 @@ export default async function SupplierDetailPage({ params }: { params: Promise<{
       <SupplierDetail supplier={supplier} purchases={purchases} movements={movements} />
     </div>
   );
-}
-
-export async function generateStaticParams() {
-  try {
-    const suppliersCollection = collection(db, 'suppliers');
-    const suppliersSnapshot = await getDocs(suppliersCollection);
-    return suppliersSnapshot.docs.map(doc => ({
-        id: doc.id,
-    }));
-  } catch (error) {
-    console.error("Failed to generate static params for suppliers:", error);
-    return [];
-  }
 }


### PR DESCRIPTION
## Summary
- fetch supplier data dynamically at runtime

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: prompts for interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68a9f89970348329bba62afc02eaff2f