### PR TITLE
feat: wrap cadastros tabs in suspense

### DIFF
--- a/src/app/cadastros/page.tsx
+++ b/src/app/cadastros/page.tsx
@@ -1,6 +1,6 @@
-
 'use client';
 
+import { Suspense } from 'react';
 import { useSearchParams } from 'next/navigation';
 import PageHeader from '@/components/page-header';
 import { SupplierList } from './components/supplier-list';
@@ -11,7 +11,7 @@ import { IngredientList } from './components/ingredient-list';
 import { SalespersonList } from './components/salesperson-list';
 import { EmployeeList } from './components/employee-list';
 
-export default function CadastrosPage() {
+function CadastrosContent() {
   const searchParams = useSearchParams();
   const tab = searchParams.get('tab') || 'products';
 
@@ -19,33 +19,41 @@ export default function CadastrosPage() {
     <div className="flex-1 space-y-4 p-4 sm:p-6 lg:p-8">
       <PageHeader title="Cadastros" />
       <Tabs defaultValue={tab} className="w-full">
-          <TabsList>
-              <TabsTrigger value="products">Produtos</TabsTrigger>
-              <TabsTrigger value="ingredients">Insumos</TabsTrigger>
-              <TabsTrigger value="suppliers">Fornecedores</TabsTrigger>
-              <TabsTrigger value="salespeople">Vendedores</TabsTrigger>
-              <TabsTrigger value="employees">Funcionários</TabsTrigger>
-              <TabsTrigger value="recipes">Fichas Técnicas</TabsTrigger>
-          </TabsList>
-           <TabsContent value="products">
-            <ProductList />
-          </TabsContent>
-          <TabsContent value="ingredients">
-            <IngredientList />
-          </TabsContent>
-           <TabsContent value="suppliers">
-            <SupplierList />
-          </TabsContent>
-          <TabsContent value="salespeople">
-            <SalespersonList />
-          </TabsContent>
-           <TabsContent value="employees">
-            <EmployeeList />
-          </TabsContent>
-          <TabsContent value="recipes">
-            <RecipeList />
-          </TabsContent>
+        <TabsList>
+          <TabsTrigger value="products">Produtos</TabsTrigger>
+          <TabsTrigger value="ingredients">Insumos</TabsTrigger>
+          <TabsTrigger value="suppliers">Fornecedores</TabsTrigger>
+          <TabsTrigger value="salespeople">Vendedores</TabsTrigger>
+          <TabsTrigger value="employees">Funcionários</TabsTrigger>
+          <TabsTrigger value="recipes">Fichas Técnicas</TabsTrigger>
+        </TabsList>
+        <TabsContent value="products">
+          <ProductList />
+        </TabsContent>
+        <TabsContent value="ingredients">
+          <IngredientList />
+        </TabsContent>
+        <TabsContent value="suppliers">
+          <SupplierList />
+        </TabsContent>
+        <TabsContent value="salespeople">
+          <SalespersonList />
+        </TabsContent>
+        <TabsContent value="employees">
+          <EmployeeList />
+        </TabsContent>
+        <TabsContent value="recipes">
+          <RecipeList />
+        </TabsContent>
       </Tabs>
     </div>
+  );
+}
+
+export default function CadastrosPage() {
+  return (
+    <Suspense fallback={<div>Carregando...</div>}>
+      <CadastrosContent />
+    </Suspense>
   );
 }


### PR DESCRIPTION
## Summary
- wrap cadastros tabs in suspense with loading fallback

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint configuration)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a9f89600388329b36220a8b0d864d0