### PR TITLE
docs: use npm ci and note Node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ To get started, take a look at `src/app/page.tsx`.
 
 ## Desenvolvimento Local
 
-1. Instale as dependências: `npm install`
+Requer Node.js 18 ou superior.
+
+1. Instale as dependências: `npm ci`
 2. Inicie o servidor de desenvolvimento: `npm run dev` e acesse `http://localhost:9002`.
 
 ## Implantação na Netly


### PR DESCRIPTION
## Summary
- use `npm ci` for dependency installation
- document Node.js 18 requirement

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68aa063e3b088329bcf67662af79fbf9