### PR TITLE
build: run npm ci in Netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,9 +1,10 @@
 [build]
-  command = "npm run build"
+  command = "npm ci && npm run build"
   publish = ".next"
 
 [build.environment]
   NODE_VERSION = "18"
+  NPM_FLAGS = "--no-audit --no-fund"
 
 [[plugins]]
   package = "@netlify/plugin-nextjs"


### PR DESCRIPTION
## Summary
- use `npm ci` in Netlify build command
- set `NPM_FLAGS` to `--no-audit --no-fund`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: How would you like to configure ESLint?)*
- `npm run typecheck`
- `npm run build` *(fails: Missing NEXT_PUBLIC_NETLY_API_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68aa063a7b5c8329baa64cef6898501b