### PR TITLE
docs: use npm ci and note Node.js version

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ To get started, take a look at `src/app/page.tsx`.
 
 ## Desenvolvimento Local
 
-1. Instale as dependências: `npm install`
+Certifique-se de usar Node.js 18 ou superior.
+
+1. Instale as dependências: `npm ci`
 2. Inicie o servidor de desenvolvimento: `npm run dev` e acesse `http://localhost:9002`.
 
 ## Implantação na Netly


### PR DESCRIPTION
## Summary
- document Node.js 18 requirement
- recommend `npm ci` for dependency installation

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires interactive ESLint setup)


------
https://chatgpt.com/codex/tasks/task_e_68aa000e68848329ba0df90885eb1013